### PR TITLE
Trim url whitespace

### DIFF
--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -123,8 +123,8 @@ const Events: React.FC = () => {
                   <div className="event" key={index}>
                     <h2>{timing.date}</h2>
                     <h1 className={`index${index % 5}`}>{value.title}</h1>
-                    {isURL(value.location) ? (
-                      <a className="link" href={getAbsoluteURL(value.location)}>
+                    {isURL(value.location.trim()) ? (
+                      <a className="link" href={getAbsoluteURL(value.location.trim())}>
                         <h3>{value.location}</h3>
                       </a>
                     ) : (


### PR DESCRIPTION
wow it's linking now 🔗🔗

The event accidentally had a whitespace at the end. Events are checked for URL structure to determine whether to display an `<a>` or `<h3>` and the whitespace threw it off. Trimming fixed the issue
