### PR TITLE
Delete moving arrow animation

### DIFF
--- a/src/components/ScrollDownArrow/index.tsx
+++ b/src/components/ScrollDownArrow/index.tsx
@@ -13,7 +13,7 @@ const ScrollDownArrow = () => {
 
   return (
     <img
-      className={`arrow ${scrolled ? 'scrolled' : ''}`}
+      className={`arrow ${scrolled ? 'hide' : 'show'}`}
       alt="Scroll Arrow"
       onClick={() =>
         window.scrollBy({

--- a/src/components/ScrollDownArrow/index.tsx
+++ b/src/components/ScrollDownArrow/index.tsx
@@ -11,10 +11,10 @@ const ScrollDownArrow = () => {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  return scrolled ? null : (
+  return (
     <img
-      className="arrow"
-      alt=""
+      className={`arrow ${scrolled ? 'scrolled' : ''}`}
+      alt="Scroll Arrow"
       onClick={() =>
         window.scrollBy({
           top: window.innerHeight - 78,

--- a/src/components/ScrollDownArrow/styles.scss
+++ b/src/components/ScrollDownArrow/styles.scss
@@ -1,32 +1,25 @@
 .arrow {
   cursor: pointer;
-  left: 50vw;
+  left: calc(50vw - 15px);
   bottom: 50px;
   height: 30px;
   margin: auto;
   position: absolute;
   width: 30px;
-  animation: ca3_fade_move_down 1.5s ease-in-out infinite;
-
-  @keyframes ca3_fade_move_down {
-    0% {
-      transform: translate(0, -10px);
-      opacity: 0;
-    }
-    35% {
-      opacity: 1;
-    }
-    70% {
-      transform: translate(0, 10px);
-      opacity: 0;
-    }
-    100% {
-      transform: translate(0, 10px);
-      opacity: 0;
-    }
-  }
-
   @media only screen and (max-width: 1050px) {
     display: none;
   }
+}
+
+@keyframes hide {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.scrolled {
+  animation: hide 0.5s linear 0s 1 normal forwards;
 }

--- a/src/components/ScrollDownArrow/styles.scss
+++ b/src/components/ScrollDownArrow/styles.scss
@@ -20,6 +20,19 @@
   }
 }
 
-.scrolled {
+.hide {
   animation: hide 0.5s linear 0s 1 normal forwards;
+}
+
+@keyframes show {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.show {
+  animation: show 0.5s linear 0s 1 normal forwards;
 }


### PR DESCRIPTION
<!-- Note that your PR will likely start off as a draft PR, since you'll need to test the deployed preview first. -->

# Description
- Previous arrow animation moved the actual clickable region and could be difficult to see with the fading opacity
- Deleted old keyframe and changed to fade arrow out when we scroll.
- Instead of rendering the arrow out of view conditionally, we render it with a class animation to maintain a smooth transition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Logistical Change (something about code process / a readme change / documentation update)
- [ ] CI Change (relating to deployment / continuous integration)
- [ ] Something Else <!-- Edit this type of change if you select this -->

# How Has This Been Tested?
- [x] Tested on Localhost
- [x] Tested on Deployed Preview


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code as needed, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (if they do, please explain why)
