### PR TITLE
fix index offset

### DIFF
--- a/src/sections/event/Event.Content.tsx
+++ b/src/sections/event/Event.Content.tsx
@@ -6,7 +6,7 @@ import s from "./Event.module.scss";
 const EventContent: React.FC<{ event: EventObject }> = ({ event }) => {
   const month = months[new Date(event.start).getMonth()];
   const date = new Date(event.start).getDate();
-  const day = days[(new Date(event.start).getDay() + 6) % 7];
+  const day = days[new Date(event.start).getDay()];
   const time = getDateTime(event).time;
   const { committee, title, location, description, start, end, facebookUrl } = event;
 

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -135,4 +135,4 @@ export const months = [
   "Dec",
 ];
 
-export const days = ["Mon", "Tues", "Wed", "Thurs", "Fri", "Sat", "Sun"];
+export const days = ["Sun", "Mon", "Tues", "Wed", "Thurs", "Fri", "Sat"];


### PR DESCRIPTION
# Description

turns out this wasn't a utc time conversion issue, our date array index is just consistently off by one even locally

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Logistical Change (something about code process / a readme change / documentation update)
- [ ] CI Change (relating to deployment / continuous integration)
- [ ] Something Else <!-- Edit this type of change if you select this -->

# How Has This Been Tested?
- [x] Tested on Localhost
- [x] Tested on Deployed Preview


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code as needed, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (if they do, please explain why)
