### PR TITLE
Added padding around board member profile images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 # local env files
 .env
 .env.local
+.env.development
 .env.development.local
 .env.test.local
 .env.production.local

--- a/src/components/BoardCard/styles.module.scss
+++ b/src/components/BoardCard/styles.module.scss
@@ -4,7 +4,7 @@
   position: relative;
   background: colors.$white;
   width: 175px;
-  height: 250px;
+  height: 256px;
   border: 3px solid;
   box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.25);
   border-radius: 16px;
@@ -37,12 +37,12 @@
     position: relative;
     grid-area: 2 / 1 / 3 / 2;
     overflow: hidden;
+    padding: 0px 10px;
 
     .photo {
       object-fit: cover;
       object-position: center top;
-      // Using px not rem because it is hardcoded in the component
-      transform: translateY(-16px);
+      border-radius: 8px;
     }
     .default {
       object-fit: contain;


### PR DESCRIPTION
<!-- Note that your PR will likely start off as a draft PR, since you'll need to test the deployed preview first. -->

# Description

Updates the image layout in the BoardCard component for a cleaner layout. Removed the `translateY(-16px)` positioning and replaced it with `padding: 0px 10px` and `border-radius: 8px` resulting in whitespace between the image and the edges of the card.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Logistical Change (something about code process / a readme change / documentation update)
- [ ] CI Change (relating to deployment / continuous integration)
- [ ] Something Else <!-- Edit this type of change if you select this -->

# How Has This Been Tested?
- [x] Tested on Localhost (Desktop)
- [ ] Tested on Localhost (Mobile) - use https://ngrok.io to get a copy on a mobile device
- [x] Tested on Deployed Preview (Desktop)
- [x] Tested on Deployed Preview (Mobile)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code as needed, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (if they do, please explain why)
